### PR TITLE
new version of google-oauth-plugin and fix gcloud path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>google-oauth-plugin</artifactId>
-			<version>0.3</version>
+			<version>0.4</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudBuildWrapper.java
+++ b/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudBuildWrapper.java
@@ -73,6 +73,7 @@ public class GCloudBuildWrapper extends SimpleBuildWrapper {
             context.env(entry.getKey(), entry.getValue());
         }
         context.env("CLOUDSDK_CONFIG", configDir.getRemote());
+        context.env("GOOGLE_APPLICATION_CREDENTIALS", serviceAccount.getKeyFile().getRemote());
 
         context.setDisposer(new GCloudConfigDisposer(configDir));
 	}

--- a/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudSDKBuilder.java
+++ b/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudSDKBuilder.java
@@ -2,6 +2,7 @@ package com.byclosure.jenkins.plugins.gcloud;
 
 
 import com.google.jenkins.plugins.credentials.domains.RequiresDomain;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -17,9 +18,11 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.util.logging.Logger;
 
 @RequiresDomain(value = GCloudScopeRequirement.class)
 public class GCloudSDKBuilder extends Builder {
+	private static final Logger LOGGER = Logger.getLogger(GCloudSDKBuilder.class.getName());
 
 	private final String command;
 
@@ -42,9 +45,13 @@ public class GCloudSDKBuilder extends Builder {
 	}
 
 	private boolean executeGCloudCLI(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+		EnvVars env = build.getEnvironment(listener);
+		String binariesPath = env.get("CLOUDSDK_DIR")+"/bin/";
+
 		int retCode = launcher.launch()
 				.pwd(build.getWorkspace())
-				.cmdAsSingleString("gcloud " + command)
+				.cmdAsSingleString(binariesPath + "gcloud " + command)
+				.envs(env)
 				.stdout(listener.getLogger())
 				.join();
 

--- a/src/main/java/com/byclosure/jenkins/plugins/gcloud/TemporaryKeyFile.java
+++ b/src/main/java/com/byclosure/jenkins/plugins/gcloud/TemporaryKeyFile.java
@@ -1,18 +1,20 @@
 package com.byclosure.jenkins.plugins.gcloud;
 
 import hudson.FilePath;
-import hudson.Launcher;
-import hudson.model.AbstractBuild;
 
-import java.io.File;
 import java.io.IOException;
 
 class TemporaryKeyFile {
 	private FilePath tmpKeyFile;
 
-	public TemporaryKeyFile(FilePath configDir, File keyFile) throws IOException, InterruptedException {
+	public TemporaryKeyFile(FilePath configDir, String content) throws IOException, InterruptedException {
 		tmpKeyFile = configDir.createTempFile("gcloud", "key");
-		tmpKeyFile.copyFrom(new FilePath(keyFile));
+		tmpKeyFile.write(content, "UTF-8");
+	}
+
+	public TemporaryKeyFile(FilePath configDir, FilePath file) throws IOException, InterruptedException {
+		tmpKeyFile = configDir.createTempFile("gcloud", "key");
+		tmpKeyFile.copyFrom(file);
 	}
 
 	public FilePath getKeyFile() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/gcloudsdk/GCloudInstallation.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/gcloudsdk/GCloudInstallation.java
@@ -28,6 +28,7 @@ public class GCloudInstallation extends ToolInstallation implements NodeSpecific
 
     public void buildEnvVars(EnvVars env) {
         env.override("PATH+GCLOUD", getHome()+"/bin");
+        env.override("CLOUDSDK_DIR", getHome());
         env.override("CLOUDSDK_PYTHON_SITEPACKAGES", "1");
     }
 


### PR DESCRIPTION
Since google-oauth-plugin now ciphers the private key json file, we need to retrieve it, and decipher in order to use it during the build.

Another problem is the PATH+GCLOUD is not changing the PATH environment variable through all the build steps.