### PR TITLE
Update GCloudSDKWithAuthBuilder.java

### DIFF
--- a/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudSDKWithAuthBuilder.java
+++ b/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudSDKWithAuthBuilder.java
@@ -63,7 +63,7 @@ public class GCloudSDKWithAuthBuilder extends Builder {
 	private boolean executeGCloudCLI(AbstractBuild build, Launcher launcher, BuildListener listener, FilePath configDir) throws IOException, InterruptedException {
 		int retCode = launcher.launch()
 				.pwd(build.getWorkspace())
-				.cmdAsSingleString("gcloud " + command)
+				.cmdAsSingleString(command)
 				.stdout(listener.getLogger())
                 .envs("CLOUDSDK_CONFIG=" + configDir.getRemote())
                 .join();


### PR DESCRIPTION
I would like to deploy maven application onto Google App Engine. But it won't support deployment through gcloud app deploy. So I would like to use this plugin to deploy application where maven command can be provided directly at command option so that it will execute maven command from gcloud with Authentication.