### PR TITLE
Restrict GCloudInstaller to GCloudInstallation types

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/gcloudsdk/GCloudInstaller.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/gcloudsdk/GCloudInstaller.java
@@ -68,6 +68,11 @@ public class GCloudInstaller extends DownloadFromUrlInstaller {
         public List<? extends Installable> getInstallables() throws IOException {
             return Collections.singletonList(SDK);
         }
+
+        @Override
+        public boolean isApplicable(Class<? extends ToolInstallation> toolType) {
+            return GCloudInstallation.class.isAssignableFrom(toolType);
+        }
     }
 
 


### PR DESCRIPTION
This prevents "Install from google.com" showing for tool types this installer does not handle.