### PR TITLE
Gracefully handle empty installation or credentials

### DIFF
--- a/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudBuildWrapper.java
+++ b/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudBuildWrapper.java
@@ -48,6 +48,11 @@ public class GCloudBuildWrapper extends SimpleBuildWrapper {
     public void setUp(Context context, Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
 
         GCloudInstallation sdk = getSDK();
+
+        if (sdk == null) {
+            throw new RuntimeException("Could not find a matching Google Cloud SDK installation: " + installation);
+        }
+
         sdk = sdk.translate(workspace.toComputer().getNode(), initialEnvironment, listener);
         final FilePath configDir = workspace.createTempDir("gcloud", "config");
 

--- a/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudBuildWrapper.java
+++ b/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudBuildWrapper.java
@@ -71,6 +71,11 @@ public class GCloudBuildWrapper extends SimpleBuildWrapper {
 
     public @CheckForNull GCloudInstallation getSDK() {
         GCloudInstallation[] installations = GCloudInstallation.getInstallations();
+
+        if (installation.isEmpty() && installations.length > 0) {
+            return installations[0];
+        }
+
         for (GCloudInstallation sdk : installations) {
             if (installation.equals(sdk.getName())) return sdk;
         }

--- a/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudBuildWrapper.java
+++ b/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudBuildWrapper.java
@@ -12,20 +12,12 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.Launcher.DecoratedLauncher;
-import hudson.Proc;
-import hudson.Util;
-import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.Computer;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.security.ACL;
-import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
-import hudson.tools.ToolInstallation;
 import hudson.util.ListBoxModel;
 import jenkins.tasks.SimpleBuildWrapper;
 import net.sf.json.JSONObject;
@@ -36,7 +28,6 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.CheckForNull;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.Map;
 import java.util.logging.Logger;
 

--- a/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudServiceAccount.java
+++ b/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudServiceAccount.java
@@ -30,6 +30,10 @@ public class GCloudServiceAccount {
 				new GCloudScopeRequirement()
 		);
 
+		if (credential == null) {
+			return null;
+		}
+
 		final ServiceAccountConfig serviceAccountConfig = credential.getServiceAccountConfig();
 
 		final String accountId = serviceAccountConfig.getAccountId();


### PR DESCRIPTION
The default selection for the gcloud installation is typically `(Default)`, which translates into the config as empty string `""`. The method of selecting which installation to use was not accounting for this possibility, and caused the plugin to fail with a nondescript NullPointerException. If you selected a non-`(Default)` installation, however, it would work fine.
Now, if the config was requesting `(Default)` installation type, and there is an available installer/installation available, it will select that one by default.  Otherwise it will look for whichever named installation you had selected.

Similarly, the default credentials selection is the blank `-none-` option. Trying to use that (no credentials) would again result in a nondescript NullPointerException and no clear indication of what the problem was.
Now, if you selected `-none-` as the credential in the build wrapper, it will continue along happily as if you simply had not authenticated. Everything works well, up until you try to use an auth-required command, and then the build step will fail (as expected).
This also allows you to select `-none-` as the Build Wrapper's credential, but then use the `Execute gcloud CLI (with auth)` build step to select a proper service account.

All this is now working as expected.