### PR TITLE
Use google-oauth-plugin v0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,12 @@
 	<version>0.0.2-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 
+	<properties>
+		<jenkins.version>2.60.3</jenkins.version>
+		<java.level>8</java.level>
+		<doclint>none</doclint>
+	</properties>
+
 	<name>GCloud SDK Plugin</name>
 	<description>GCloud SDK Plugin allows users to invoke gcloud tools with jenkins credentials.</description>
 	<url>https://wiki.jenkins-ci.org/display/JENKINS/GCloud+SDK+Plugin</url>
@@ -55,9 +61,15 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.kohsuke</groupId>
+			<artifactId>access-modifier-suppressions</artifactId>
+			<version>1.16</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>google-oauth-plugin</artifactId>
-			<version>0.4</version>
+			<version>0.8</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudServiceAccount.java
+++ b/src/main/java/com/byclosure/jenkins/plugins/gcloud/GCloudServiceAccount.java
@@ -2,17 +2,17 @@ package com.byclosure.jenkins.plugins.gcloud;
 
 import com.cloudbees.jenkins.plugins.gcloudsdk.GCloudInstallation;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.SecretBytes;
 import com.google.api.client.json.jackson.JacksonFactory;
 import com.google.jenkins.plugins.credentials.oauth.*;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
-import java.io.File;
-import java.io.FileInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.logging.Logger;
 
 public class GCloudServiceAccount {
 	private final Launcher launcher;
@@ -38,13 +38,14 @@ public class GCloudServiceAccount {
 		return new GCloudServiceAccount(launcher, listener, accountId, tmpKeyFile, configDir);
 	}
 
+	@SuppressRestrictedWarnings(JsonServiceAccountConfig.class)
 	private static TemporaryKeyFile getKeyFile(ServiceAccountConfig serviceAccount, FilePath configDir) {
 		TemporaryKeyFile tmpKeyFile = null;
 
 		try {
 			if (serviceAccount instanceof JsonServiceAccountConfig) {
-				String keyFilePath = ((JsonServiceAccountConfig)serviceAccount).getJsonKeyFile();
-				JsonKey key = JsonKey.load(new JacksonFactory(), new FileInputStream(new File(keyFilePath)));
+				SecretBytes secretKey = ((JsonServiceAccountConfig) serviceAccount).getSecretJsonKey();
+				JsonKey key = JsonKey.load(new JacksonFactory(), new ByteArrayInputStream(secretKey.getPlainData()));
 				tmpKeyFile = new TemporaryKeyFile(configDir, key.toPrettyString());
 			} else if (serviceAccount instanceof P12ServiceAccountConfig) {
 				String keyFilePath = ((P12ServiceAccountConfig)serviceAccount).getP12KeyFile();


### PR DESCRIPTION
As of v0.8, the key is no longer exposed as a JSON file, but instead it only
exposes the accountId and privateKey. In order to use the key with the gcloud
SDK, we need to be able to pass the path to a JSON file.